### PR TITLE
add garbage collection

### DIFF
--- a/deepprofiler/imaging/cropping.py
+++ b/deepprofiler/imaging/cropping.py
@@ -1,3 +1,4 @@
+import gc
 import threading
 import pandas as pd
 import time
@@ -236,6 +237,7 @@ class CropGenerator(object):
     def stop(self, session):
         self.coord.request_stop()
         self.coord.join(self.queue_threads)
+        gc.collect()
 
 
 #######################################################

--- a/deepprofiler/learning/training.py
+++ b/deepprofiler/learning/training.py
@@ -1,3 +1,4 @@
+import gc
 import os
 
 import tensorflow as tf
@@ -30,7 +31,7 @@ def learn_model(config, dset, epoch):
         crop_session = tf.Session(config = cpu_config)
 
         crop_generator.start(crop_session)
-
+        gc.collect()
     # Start main session
     configuration = tf.ConfigProto()
     configuration.gpu_options.visible_device_list = "0"
@@ -124,4 +125,4 @@ def learn_model(config, dset, epoch):
     crop_generator.stop(crop_session)
     crop_session.close()
     print(" All set.")
-
+    gc.collect()

--- a/tests/learning/test_training.py
+++ b/tests/learning/test_training.py
@@ -1,4 +1,3 @@
-import gc
 import os
 import random
 
@@ -123,7 +122,6 @@ def test_learn_model(config, dataset, data, locations, out_dir):
     assert os.path.exists(os.path.join(out_dir, "checkpoint_0001.hdf5"))
     assert os.path.exists(os.path.join(out_dir, "checkpoint_0002.hdf5"))
     assert os.path.exists(os.path.join(out_dir, "log.csv"))
-    gc.collect()
     epoch = 3
     config['training']['epochs'] = 4
     deepprofiler.learning.training.learn_model(config, dataset, epoch)


### PR DESCRIPTION
Adding garbage collection to free up memory after multithreading or tensorflow operations are used prevents segmentation faults with tensorflow.